### PR TITLE
include license file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license-file = LICENSE.txt


### PR DESCRIPTION
Life is easier when you include the text of your license in distributions of the package. The `MANIFEST.in` here makes sure that `LICENSE.txt` is included in the `tar.gz` files made by `sdist`, while the `setup.cfg` change tells wheels about it.