### PR TITLE
Added CNAME file to configure pyviz subdomain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+colorcet.pyviz.org


### PR DESCRIPTION
This will enable ``colorcet.pyviz.org``.